### PR TITLE
Regression error fix.

### DIFF
--- a/sty/statements/statements.dtx
+++ b/sty/statements/statements.dtx
@@ -1215,7 +1215,7 @@ DefConstructor('\adefii[]{}{}{} OptionalKeyVals:DEF',
 	         .       "#2"
 	         .    "</omdoc:term>"
 		 ."?#defindex(</omdoc:idt><omdoc:ide index='default'><omdoc:idp>#3</omdoc:idp><omdoc:idp>#4</omdoc:idp></omdoc:ide></omdoc:idx>)",
-       afterDigest => sub { defHelper(@_, adefii); },
+       afterDigest => sub { defHelper(@_, 'adefii'); },
 	       alias=>'\adefii');#$
 %</ltxml>
 %    \end{macrocode}

--- a/sty/statements/statements.dtx
+++ b/sty/statements/statements.dtx
@@ -1215,7 +1215,7 @@ DefConstructor('\adefii[]{}{}{} OptionalKeyVals:DEF',
 	         .       "#2"
 	         .    "</omdoc:term>"
 		 ."?#defindex(</omdoc:idt><omdoc:ide index='default'><omdoc:idp>#3</omdoc:idp><omdoc:idp>#4</omdoc:idp></omdoc:ide></omdoc:idx>)",
-       afterDigest => sub { defHelper(@_, 'adeii'); },
+       afterDigest => sub { defHelper(@_, adefii); },
 	       alias=>'\adefii');#$
 %</ltxml>
 %    \end{macrocode}
@@ -1520,8 +1520,8 @@ sub defHelper{
                       defiii => sub {$whatsit->getArg(2)->toString.'-'.$whatsit->getArg(3)->toString.'-'.$whatsit->getArg(4)->toString;},
                       adefiii => sub {$whatsit->getArg(3)->toString.'-'.$whatsit->getArg(4)->toString.'-'.$whatsit->getArg(5)->toString;} 
                       );
-  $name = $name || $choose_Option{$defOption};
-  $whatsit->setProperty(name=>$name->toString);
+  $name = $name || $choose_Option{$defOption}->();
+  $whatsit->setProperty(name=>$name->toString) if ref($name);
   push(@$addr, $name) if ($addr and $name);
   $whatsit->setProperty('defindex', IfCondition(T_CS('\if@defindex')));
   $whatsit->setProperty(theory=>(LookupValue('modnl_signature') || LookupValue('current_module')));

--- a/sty/statements/statements.sty.ltxml
+++ b/sty/statements/statements.sty.ltxml
@@ -202,7 +202,7 @@ DefConstructor('\adefii[]{}{}{} OptionalKeyVals:DEF',
          .       "#2"
          .    "</omdoc:term>"
  ."?#defindex(</omdoc:idt><omdoc:ide index='default'><omdoc:idp>#3</omdoc:idp><omdoc:idp>#4</omdoc:idp></omdoc:ide></omdoc:idx>)",
-       afterDigest => sub { defHelper(@_, adefii); },
+       afterDigest => sub { defHelper(@_, 'adefii'); },
        alias=>'\adefii');#$
 DefConstructor('\defiii[]{}{}{} OptionalKeyVals:DEF',
  "?#defindex(<omdoc:idx><omdoc:idt>)"

--- a/sty/statements/statements.sty.ltxml
+++ b/sty/statements/statements.sty.ltxml
@@ -202,7 +202,7 @@ DefConstructor('\adefii[]{}{}{} OptionalKeyVals:DEF',
          .       "#2"
          .    "</omdoc:term>"
  ."?#defindex(</omdoc:idt><omdoc:ide index='default'><omdoc:idp>#3</omdoc:idp><omdoc:idp>#4</omdoc:idp></omdoc:ide></omdoc:idx>)",
-       afterDigest => sub { defHelper(@_, 'adeii'); },
+       afterDigest => sub { defHelper(@_, adefii); },
        alias=>'\adefii');#$
 DefConstructor('\defiii[]{}{}{} OptionalKeyVals:DEF',
  "?#defindex(<omdoc:idx><omdoc:idt>)"
@@ -336,8 +336,8 @@ sub defHelper{
                       defiii => sub {$whatsit->getArg(2)->toString.'-'.$whatsit->getArg(3)->toString.'-'.$whatsit->getArg(4)->toString;},
                       adefiii => sub {$whatsit->getArg(3)->toString.'-'.$whatsit->getArg(4)->toString.'-'.$whatsit->getArg(5)->toString;}
                       );
-  $name = $name || $choose_Option{$defOption};
-  $whatsit->setProperty(name=>$name->toString);
+  $name = $name || $choose_Option{$defOption}->();
+  $whatsit->setProperty(name=>$name->toString) if ref($name);
   push(@$addr, $name) if ($addr and $name);
   $whatsit->setProperty('defindex', IfCondition(T_CS('\if@defindex')));
   $whatsit->setProperty(theory=>(LookupValue('modnl_signature') || LookupValue('current_module')));


### PR DESCRIPTION
Sorry there were some regression errors introduced, which took my a few hours to figure out why.

```
$name = $name || $choose_Option{$defOption};
```
The right ways to call the sub by reference should be 
```
$choose_Option{$defOption}->();
```
or 
```
&{ $hash{functionName} }()
```
in a hash table. It was confusing for me, because no argument was needed, but still the braces need to be included for the sub to work, (dark evil of Perl : <<<<<<< )

Also `toString` method cannot be called again on `defii`, `adefii`, `defiii`, `adefiii` as their `$names` are already converted to string. So we have to check if $name has the reference, meaning if they are `HASH.`
 