### PR TITLE
Remove duplicated ids.

### DIFF
--- a/sty/modules/modules.sty.ltxml
+++ b/sty/modules/modules.sty.ltxml
@@ -384,8 +384,7 @@ DefConstructor('\@symdef@construct@presentation{}{}{}{}{} OptionalKeyVals:symdef
   my $root = $document->getDocument->documentElement;
   $name = ToString($name);
   my $id;
-  $id = ToString($keys->getValue('id')) if $keys;
-  $id = $name.".sym" unless $id;
+  $id = $cs.".sym" unless $cs;
   # There has to be a nicer API for doing this in LaTeXML::Core::Document...
   $root->setNamespace("http://omdoc.org/ns","omdoc",0);
   $root->setNamespace("http://kwarc.info/ns/sTeX","stex",0);


### PR DESCRIPTION
Given:
```latex
\begin{module}[id=test]
\symdef[name=bar]{barOp}{B}
\symdef{bar}[1]{B_{#1}}
\end{module}
```
We have 
```xml
  <omdoc:theory xml:id="test" about="#test" stex:srcref="MiKoMH/GenCS/source/codes/en/test.tex#textrange(from=1;0,to=4;12)">
    <omdoc:symbol name="bar" xml:id="test.symbol1" about="#test.symbol1" stex:srcref="MiKoMH/GenCS/source/codes/en/test.tex#textrange(from=2;0,to=2;27)"/>
    <omdoc:notation cd="test" name="bar" stex:macro_name="barOp" stex:nargs="0" xml:id="test.notation2" about="#test.notation2" stex:srcref="MiKoMH/GenCS/source/codes/en/test.tex#textrange(from=2;0,to=2;27)">
      <omdoc:prototype>
        <om:OMS cd="test" name="bar"/>
      </omdoc:prototype>
      <omdoc:rendering xml:lang="de">
        <m:mi>B</m:mi>
      </omdoc:rendering>
    </omdoc:notation>
    <omdoc:symbol name="bar" xml:id="test.symbol3" about="#test.symbol3" stex:srcref="MiKoMH/GenCS/source/codes/en/test.tex#textrange(from=3;0,to=3;23)"/>
    <omdoc:notation cd="test" name="bar" stex:macro_name="bar" stex:nargs="1" xml:id="test.notation4" about="#test.notation4" stex:srcref="MiKoMH/GenCS/source/codes/en/test.tex#textrange(from=3;0,to=3;23)">
      <omdoc:prototype>
        <om:OMA>
          <om:OMS cd="test" cr="fun" name="bar"/>
          <omdoc:expr name="arg1"/>
        </om:OMA>
      </omdoc:prototype>
      <omdoc:rendering xml:lang="de">
        <m:msub>
          <m:mi>B</m:mi>
          <omdoc:render name="arg1"/>
        </m:msub>
      </omdoc:rendering>
    </omdoc:notation>
  </omdoc:theory>
```