### PR TITLE
Travis texlive2013

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,22 @@
+sudo: required
+dist: trusty
 language: perl
 
 before_install:
- - sudo add-apt-repository -y ppa:texlive-backports/ppa
  - sudo apt-get update -qq
- - sudo apt-get install libdb-dev libxml2-dev libxslt1-dev texlive texlive-fonts-extra texlive-latex-extra texlive-lang-cyrillic biblatex trang
+ - sudo apt-get install -qq libdb-dev libxml2-dev libxslt1-dev texlive texlive-fonts-extra texlive-latex-extra texlive-lang-cyrillic biber trang
 
 install:
- - wget http://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/development/binaries/Linux/biber-linux_x86_64.tar.gz
- - tar zxf biber-linux_x86_64.tar.gz
  - git clone https://github.com/KWARC/LaTeXML
  - cd LaTeXML
  - cpanm --installdeps .
  - cpanm -v .
  - cd ..
- - cp biber LaTeXML/bin
+ - cp LaTeXML/lib/LaTeXML/texmf/latexml.sty sty
 
 script:
  - export BIBINPUTS=`pwd`/bib
  - export PATH=$PATH:`pwd`/LaTeXML/bin
  - export STEXDIR=`pwd`
- - export TEXINPUTS=`pwd`/sty 
+ - export TEXINPUTS=`pwd`/sty
  - make
- - cat sty/cnx/cnx.log
- - cat sty/dcm/dcm.log
- - cat sty/omdoc/omdoc.log

--- a/sty/Makefile
+++ b/sty/Makefile
@@ -1,6 +1,6 @@
 # recurse into the directories. 
 DISTDIRS = cmath cmathml cnx dcm hwexam metakeys mikoslides modules omdoc omtext\
-	   presentation problem rdfmeta reqdoc sproof sref statements workaddress\
+	   presentation problem rdfmeta reqdoc sproof statements workaddress\
            smultiling tikzinput smglom
 MAKEDIRS = $(DISTDIRS) #physml owl2onto
 

--- a/sty/Makefile
+++ b/sty/Makefile
@@ -5,7 +5,7 @@ DISTDIRS = cmath cmathml cnx dcm hwexam metakeys mikoslides modules omdoc omtext
 MAKEDIRS = $(DISTDIRS) #physml owl2onto
 
 all ltxml package doc filedate checksum enablechecksum disablechecksum clean distclean: 
-	@for d in $(MAKEDIRS); do (cd $$d && $(MAKE) -$(MAKEFLAGS) $@) done
+	@for d in $(MAKEDIRS); do (cd $$d && $(MAKE) -$(MAKEFLAGS) $@) || exit $$?; done
 
 TDSCOLL = stex
 TDS.tex = stex.tex stex.sty stex.sty.ltxml stex-logo.sty stex-logo.sty.ltxml ctansvn.sty

--- a/sty/statements/statements.bbl
+++ b/sty/statements/statements.bbl
@@ -1,5 +1,5 @@
 % $ biblatex auxiliary file $
-% $ biblatex bbl format version 2.5 $
+% $ biblatex bbl format version 2.4 $
 % Do not modify the above lines!
 %
 % This is an auxiliary file used by the 'biblatex' package.
@@ -20,6 +20,10 @@
 \refsection{0}
   \sortlist{anyt}{anyt}
     \entry{KohGin:smss:svn}{report}{}
+      \name{labelname}{2}{}{%
+        {{hash=2e832785205772b3f6e09c93b51d6e74}{Kohlhase}{K\bibinitperiod}{Michael}{M\bibinitperiod}{}{}{}{}}%
+        {{hash=d72ad64c572c227e5fcd5a3c47e53753}{Ginev}{G\bibinitperiod}{Deyan}{D\bibinitperiod}{}{}{}{}}%
+      }
       \name{author}{2}{}{%
         {{hash=2e832785205772b3f6e09c93b51d6e74}{Kohlhase}{K\bibinitperiod}{Michael}{M\bibinitperiod}{}{}{}{}}%
         {{hash=d72ad64c572c227e5fcd5a3c47e53753}{Ginev}{G\bibinitperiod}{Deyan}{D\bibinitperiod}{}{}{}{}}%
@@ -28,9 +32,8 @@
       \strng{fullhash}{539e845a4eee142766e72b2508aef16a}
       \field{labelalpha}{KG15}
       \field{sortinit}{K}
-      \field{sortinithash}{a7d5b3aec5a0890aae7baf85a209abfc}
-      \field{labelnamesource}{author}
-      \field{labeltitlesource}{title}
+      \field{sortinithash}{33bf4c961fa093ee6a297ccbd88eacc0}
+      \field{labeltitle}{{\texttt{smultiling.sty}}: Multilinguality Support for {sTeX}}
       \field{title}{{\texttt{smultiling.sty}}: Multilinguality Support for {sTeX}}
       \field{type}{techreport}
       \field{year}{2015}
@@ -39,6 +42,11 @@
       \endverb
     \endentry
     \entry{KohAmb:smmssl:ctan}{report}{}
+      \name{labelname}{3}{}{%
+        {{hash=2e832785205772b3f6e09c93b51d6e74}{Kohlhase}{K\bibinitperiod}{Michael}{M\bibinitperiod}{}{}{}{}}%
+        {{hash=d72ad64c572c227e5fcd5a3c47e53753}{Ginev}{G\bibinitperiod}{Deyan}{D\bibinitperiod}{}{}{}{}}%
+        {{hash=05c93b9fbf514de4c6ec52be37ed7836}{Ambrus}{A\bibinitperiod}{Rares}{R\bibinitperiod}{}{}{}{}}%
+      }
       \name{author}{3}{}{%
         {{hash=2e832785205772b3f6e09c93b51d6e74}{Kohlhase}{K\bibinitperiod}{Michael}{M\bibinitperiod}{}{}{}{}}%
         {{hash=d72ad64c572c227e5fcd5a3c47e53753}{Ginev}{G\bibinitperiod}{Deyan}{D\bibinitperiod}{}{}{}{}}%
@@ -51,9 +59,8 @@
       \strng{fullhash}{9931860cf2aba7aab09916be7419d0be}
       \field{labelalpha}{KGA15}
       \field{sortinit}{K}
-      \field{sortinithash}{a7d5b3aec5a0890aae7baf85a209abfc}
-      \field{labelnamesource}{author}
-      \field{labeltitlesource}{title}
+      \field{sortinithash}{33bf4c961fa093ee6a297ccbd88eacc0}
+      \field{labeltitle}{{\texttt{modules.sty}}: Semantic Macros and Module Scoping in {sTeX}}
       \field{title}{{\texttt{modules.sty}}: Semantic Macros and Module Scoping in {sTeX}}
       \field{type}{techreport}
       \field{year}{2015}
@@ -62,6 +69,9 @@
       \endverb
     \endentry
     \entry{Kohlhase:OMDoc1.2}{book}{}
+      \name{labelname}{1}{}{%
+        {{hash=2e832785205772b3f6e09c93b51d6e74}{Kohlhase}{K\bibinitperiod}{Michael}{M\bibinitperiod}{}{}{}{}}%
+      }
       \name{author}{1}{}{%
         {{hash=2e832785205772b3f6e09c93b51d6e74}{Kohlhase}{K\bibinitperiod}{Michael}{M\bibinitperiod}{}{}{}{}}%
       }
@@ -72,9 +82,8 @@
       \strng{fullhash}{2e832785205772b3f6e09c93b51d6e74}
       \field{labelalpha}{Koh06}
       \field{sortinit}{K}
-      \field{sortinithash}{a7d5b3aec5a0890aae7baf85a209abfc}
-      \field{labelnamesource}{author}
-      \field{labeltitlesource}{title}
+      \field{sortinithash}{33bf4c961fa093ee6a297ccbd88eacc0}
+      \field{labeltitle}{\textsc{OMDoc} -- An open markup format for mathematical documents [Version 1.2]}
       \field{booktitle}{\textsc{OMDoc} -- An open markup format for mathematical documents [Version 1.2]}
       \field{month}{08}
       \field{number}{4180}
@@ -86,32 +95,36 @@
       \endverb
     \endentry
     \entry{Kohlhase:ulsmf08}{article}{}
+      \name{labelname}{1}{}{%
+        {{hash=2e832785205772b3f6e09c93b51d6e74}{Kohlhase}{K\bibinitperiod}{Michael}{M\bibinitperiod}{}{}{}{}}%
+      }
       \name{author}{1}{}{%
         {{hash=2e832785205772b3f6e09c93b51d6e74}{Kohlhase}{K\bibinitperiod}{Michael}{M\bibinitperiod}{}{}{}{}}%
       }
       \list{publisher}{1}{%
-        {Birkh\"{a}user}%
+        {Birkh{\"{a}}user}%
       }
       \strng{namehash}{2e832785205772b3f6e09c93b51d6e74}
       \strng{fullhash}{2e832785205772b3f6e09c93b51d6e74}
       \field{labelalpha}{Koh08}
       \field{sortinit}{K}
-      \field{sortinithash}{a7d5b3aec5a0890aae7baf85a209abfc}
-      \field{labelnamesource}{author}
-      \field{labeltitlesource}{title}
+      \field{sortinithash}{33bf4c961fa093ee6a297ccbd88eacc0}
+      \field{labeltitle}{Using {\LaTeX} as a Semantic Markup Format}
       \field{journaltitle}{Mathematics in Computer Science}
       \field{number}{2}
       \field{title}{Using {\LaTeX} as a Semantic Markup Format}
       \field{volume}{2}
       \field{year}{2008}
       \field{pages}{279\bibrangedash 304}
-      \range{pages}{26}
       \verb{url}
       \verb https://svn.kwarc.info/repos/stex/doc/mcs08/stex.pdf
       \endverb
       \keyw{lamapunbibs}
     \endentry
     \entry{Kohlhase:metakeys:ctan}{report}{}
+      \name{labelname}{1}{}{%
+        {{hash=2e832785205772b3f6e09c93b51d6e74}{Kohlhase}{K\bibinitperiod}{Michael}{M\bibinitperiod}{}{}{}{}}%
+      }
       \name{author}{1}{}{%
         {{hash=2e832785205772b3f6e09c93b51d6e74}{Kohlhase}{K\bibinitperiod}{Michael}{M\bibinitperiod}{}{}{}{}}%
       }
@@ -122,10 +135,9 @@
       \strng{fullhash}{2e832785205772b3f6e09c93b51d6e74}
       \field{labelalpha}{Koh15}
       \field{sortinit}{K}
-      \field{sortinithash}{a7d5b3aec5a0890aae7baf85a209abfc}
+      \field{sortinithash}{33bf4c961fa093ee6a297ccbd88eacc0}
+      \field{labeltitle}{\texttt{metakeys.sty}: A generic framework for extensible Metadata in {\LaTeX}}
       \field{extraalpha}{1}
-      \field{labelnamesource}{author}
-      \field{labeltitlesource}{title}
       \field{title}{\texttt{metakeys.sty}: A generic framework for extensible Metadata in {\LaTeX}}
       \field{type}{techreport}
       \field{year}{2015}
@@ -134,6 +146,9 @@
       \endverb
     \endentry
     \entry{Kohlhase:smomdl:ctan}{report}{}
+      \name{labelname}{1}{}{%
+        {{hash=2e832785205772b3f6e09c93b51d6e74}{Kohlhase}{K\bibinitperiod}{Michael}{M\bibinitperiod}{}{}{}{}}%
+      }
       \name{author}{1}{}{%
         {{hash=2e832785205772b3f6e09c93b51d6e74}{Kohlhase}{K\bibinitperiod}{Michael}{M\bibinitperiod}{}{}{}{}}%
       }
@@ -144,10 +159,9 @@
       \strng{fullhash}{2e832785205772b3f6e09c93b51d6e74}
       \field{labelalpha}{Koh15}
       \field{sortinit}{K}
-      \field{sortinithash}{a7d5b3aec5a0890aae7baf85a209abfc}
+      \field{sortinithash}{33bf4c961fa093ee6a297ccbd88eacc0}
+      \field{labeltitle}{\texttt{omdoc.sty/cls}: Semantic Markup for Open Mathematical Documents in {\LaTeX}}
       \field{extraalpha}{2}
-      \field{labelnamesource}{author}
-      \field{labeltitlesource}{title}
       \field{title}{\texttt{omdoc.sty/cls}: Semantic Markup for Open Mathematical Documents in {\LaTeX}}
       \field{type}{techreport}
       \field{year}{2015}
@@ -156,6 +170,9 @@
       \endverb
     \endentry
     \entry{Kohlhase:sref:ctan}{report}{}
+      \name{labelname}{1}{}{%
+        {{hash=2e832785205772b3f6e09c93b51d6e74}{Kohlhase}{K\bibinitperiod}{Michael}{M\bibinitperiod}{}{}{}{}}%
+      }
       \name{author}{1}{}{%
         {{hash=2e832785205772b3f6e09c93b51d6e74}{Kohlhase}{K\bibinitperiod}{Michael}{M\bibinitperiod}{}{}{}{}}%
       }
@@ -166,10 +183,9 @@
       \strng{fullhash}{2e832785205772b3f6e09c93b51d6e74}
       \field{labelalpha}{Koh15}
       \field{sortinit}{K}
-      \field{sortinithash}{a7d5b3aec5a0890aae7baf85a209abfc}
+      \field{sortinithash}{33bf4c961fa093ee6a297ccbd88eacc0}
+      \field{labeltitle}{\texttt{sref.sty}: Semantic Crossreferencing in {\LaTeX}}
       \field{extraalpha}{3}
-      \field{labelnamesource}{author}
-      \field{labeltitlesource}{title}
       \field{title}{\texttt{sref.sty}: Semantic Crossreferencing in {\LaTeX}}
       \field{type}{techreport}
       \field{year}{2015}
@@ -178,6 +194,10 @@
       \endverb
     \endentry
     \entry{MaySch:eltte09}{misc}{}
+      \name{labelname}{2}{}{%
+        {{hash=3fdc58b941e31172cf46259ba3e6c215}{May}{M\bibinitperiod}{Wolfgang}{W\bibinitperiod}{}{}{}{}}%
+        {{hash=3171e6483936d68515bb5a532c15963e}{Schedler}{S\bibinitperiod}{Andreas}{A\bibinitperiod}{}{}{}{}}%
+      }
       \name{author}{2}{}{%
         {{hash=3fdc58b941e31172cf46259ba3e6c215}{May}{M\bibinitperiod}{Wolfgang}{W\bibinitperiod}{}{}{}{}}%
         {{hash=3171e6483936d68515bb5a532c15963e}{Schedler}{S\bibinitperiod}{Andreas}{A\bibinitperiod}{}{}{}{}}%
@@ -186,9 +206,8 @@
       \strng{fullhash}{67642c42f2bf85c6415cc69188ada37f}
       \field{labelalpha}{MS}
       \field{sortinit}{M}
-      \field{sortinithash}{2684bec41e9697b92699b46491061da2}
-      \field{labelnamesource}{author}
-      \field{labeltitlesource}{title}
+      \field{sortinithash}{4203d16473bc940d4ac780773cb7c5dd}
+      \field{labeltitle}{An Extension of the LATEX-Theorem Evironment}
       \field{title}{An Extension of the LATEX-Theorem Evironment}
       \field{type}{Self-documenting {\LaTeX} package}
       \field{urlday}{11}
@@ -201,8 +220,8 @@
     \entry{sTeX:github:on}{online}{}
       \field{labelalpha}{sTeX}
       \field{sortinit}{s}
-      \field{sortinithash}{fd1e7c5ab79596b13dbbb67f8d70fb5a}
-      \field{labeltitlesource}{title}
+      \field{sortinithash}{4125bb4c3a0eb3eaee3ea6da32eb70c8}
+      \field{labeltitle}{{KWARC/sTeX}}
       \field{label}{sTeX}
       \field{title}{{KWARC/sTeX}}
       \field{urlday}{15}


### PR DESCRIPTION
with these changes `make` is tested using texlive 2013 of a trusty distribution (which seems to be a sufficiently new setup)

the `sty/Makefile` is changed to report the first failure to avoid overlooking errors (like the one in #173)

I got a failure (sort of biblatex version clash) for the committed `sty/statements/statements.bbl` file therefore I've committed my version on top. In fact, all `.bbl` files could be deleted since they are regenerated by `make`.

To avoid the failure reported in #173 I've removed `sref` from being made. https://github.com/KWARC/sTeX/commit/938a08efa37e792cae81b5f8de17d4db81174418 should be reverted after #173 has been fixed.

side note: on order to build `problem.pdf` successfully `latexml.sty` from the LaTeXML distribution needs to be copied into the `sty` directory.

 