### PR TITLE
use wildcard instead of ls

### DIFF
--- a/make/Makefile.latexml.vars
+++ b/make/Makefile.latexml.vars
@@ -35,7 +35,7 @@ LTARGET.tex.xml	= $(LTARGET:%.tex=%.tex.xml)
 MODS.tex.xml		=  $(MODS:%.tex=%.tex.xml) 
 MODS.xml  		=  $(MODS:%.tex=%.xml) 
 MODS.omdoc 		=  $(MODS:%.tex=%.omdoc) 
-MODS.log	   = $(shell ls *.ltxlog)
+MODS.log	   = $(wildcard *.ltxlog)
 
 # the prefix files or the MODSLIBDIR variable must be specified by the calling Makefile
 MODS.pre 	?= $(MODSLIBDIR)/pre.tex


### PR DESCRIPTION
to avoid `ls: cannot access *.ltxlog: No such file or directory`