### PR TITLE
Variable class loading in omdoc.cls.ltxml.

### DIFF
--- a/sty/omdoc/omdoc.cls.ltxml
+++ b/sty/omdoc/omdoc.cls.ltxml
@@ -11,7 +11,7 @@ DeclareOption('report', sub {AssignValue('omdoc@class' => 'report');
 DeclareOption('book', sub {AssignValue('omdoc@class' => 'book');
   PassOptions('stex','sty',ToString(Digest(T_CS('\CurrentOption'))));
   PassOptions('omdoc','sty',ToString(Digest(T_CS('\CurrentOption'))));});
-DeclareOption(undef, sub  {PassOptions('article','cls',ToString(Digest(T_CS('\CurrentOption'))));
+DeclareOption(undef, sub  {PassOptions('omdoc@cls','cls',ToString(Digest(T_CS('\CurrentOption'))));
   PassOptions('omdoc','sty',ToString(Digest(T_CS('\CurrentOption'))));
   PassOptions('stex','sty',ToString(Digest(T_CS('\CurrentOption'))));});
 ProcessOptions();

--- a/sty/omdoc/omdoc.dtx
+++ b/sty/omdoc/omdoc.dtx
@@ -329,7 +329,7 @@ DeclareOption('report', sub {AssignValue('omdoc@class' => 'report');
 DeclareOption('book', sub {AssignValue('omdoc@class' => 'book'); 
   PassOptions('stex','sty',ToString(Digest(T_CS('\CurrentOption'))));
   PassOptions('omdoc','sty',ToString(Digest(T_CS('\CurrentOption'))));});
-DeclareOption(undef, sub  {PassOptions('article','cls',ToString(Digest(T_CS('\CurrentOption'))));
+DeclareOption(undef, sub  {PassOptions('omdoc@cls','cls',ToString(Digest(T_CS('\CurrentOption'))));
   PassOptions('omdoc','sty',ToString(Digest(T_CS('\CurrentOption'))));
   PassOptions('stex','sty',ToString(Digest(T_CS('\CurrentOption'))));}); 
 ProcessOptions();


### PR DESCRIPTION
Fix for #179 

When `omdoc@cls` value is supplied, the options do get passed to `(article/book/report).cls.ltxml` and this has been tested.